### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/src/neuroca/db/connections/mongo.py
+++ b/src/neuroca/db/connections/mongo.py
@@ -104,8 +104,7 @@ class MongoDBConnection:
         # Validate configuration
         self._validate_config()
         
-        logger.debug("MongoDB connection manager initialized with config: %s", 
-                    {k: v if k != 'password' else '******' for k, v in self.config.items()})
+        logger.debug("MongoDB connection manager initialized.")
 
     def _load_config_from_env(self) -> dict[str, Any]:
         """


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Neuroca/security/code-scanning/2](https://github.com/MjrTom/Neuroca/security/code-scanning/2)

To fix the problem, we should avoid logging the entire configuration dictionary, even with masked passwords. Instead, we can log a message indicating that the MongoDB connection manager has been initialized without including the configuration details. This way, we maintain the functionality of logging the initialization event without exposing any sensitive information.

- Remove the logging of the configuration dictionary.
- Replace it with a simple log message indicating successful initialization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
