### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/src/neuroca/api/middleware/__init__.py
+++ b/src/neuroca/api/middleware/__init__.py
@@ -101,7 +101,7 @@ def setup_trusted_hosts(app: FastAPI) -> None:
             TrustedHostMiddleware,
             allowed_hosts=settings.TRUSTED_HOSTS,
         )
-        logger.debug("Trusted hosts middleware configured with hosts: %s", settings.TRUSTED_HOSTS)
+        logger.debug("Trusted hosts middleware configured.")
 
 
 def setup_compression(app: FastAPI) -> None:


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Neuroca/security/code-scanning/1](https://github.com/MjrTom/Neuroca/security/code-scanning/1)

To fix the problem, we should avoid logging sensitive information such as `settings.TRUSTED_HOSTS` directly. Instead, we can log a generic message indicating that the trusted hosts middleware has been configured without including the actual values. This approach maintains the functionality of logging the configuration status while protecting sensitive information.

We need to modify the logging statement on line 104 in the file `src/neuroca/api/middleware/__init__.py` to remove the sensitive data from the log message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
